### PR TITLE
don't show space after unchanged buffer if g:bufferline_modified=''

### DIFF
--- a/autoload/bufferline.vim
+++ b/autoload/bufferline.vim
@@ -16,9 +16,12 @@ function! s:generate_names()
   let g:index_to_buffer = {}
   while i <= last_buffer
     if bufexists(i) && buflisted(i)
-      let modified = ' '
-      if getbufvar(i, '&mod')
-        let modified = g:bufferline_modified
+      let modified = ''
+      if g:bufferline_modified != ''
+        let modified = ' '
+        if getbufvar(i, '&mod')
+          let modified = g:bufferline_modified
+        endif
       endif
       let fname = fnamemodify(bufname(i), g:bufferline_fname_mod)
       if g:bufferline_pathshorten != 0

--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -27,7 +27,8 @@ values):
   let g:bufferline_active_buffer_right = ']'
 <
 
-* the symbol to denote that a buffer is modified
+* the symbol to denote that a buffer is modified (setting this to '' will
+  remove denote placeholder for unchanged buffer)
 >
   let g:bufferline_modified = '+'
 <


### PR DESCRIPTION
Since upstream is rather quiet and your fork feels active, then... this change does what titles says. I tried other approaches too, e.g. add separate variable `g:bufferline_show_modified`, but that didn't feel nice. 